### PR TITLE
Won't work on non-Debian systems

### DIFF
--- a/pointgrey_camera_driver/package.xml
+++ b/pointgrey_camera_driver/package.xml
@@ -24,6 +24,7 @@
   <build_depend>dynamic_reconfigure</build_depend>
   <build_depend>driver_base</build_depend>
   <build_depend>diagnostic_updater</build_depend>
+  <build_depend>dpkg</build_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>nodelet</run_depend>
   <run_depend>sensor_msgs</run_depend>


### PR DESCRIPTION
As it stands, the pointgrey driver will only work on Debian systems because it downloads and extracts debs. Even if we change how the debs are extracted or install dpkg on non-debian systems, the executables therein are likely linked against Debian libraries, which are not always the same version on Fedora.

Instead, would it be possible to download the source for libflycapture and compile it? This would make this package work on Fedora, Arch and OSX.

cc @bchretien
