### PR TITLE
Should prevent multiple camera nodes from conflicting.

### DIFF
--- a/pointgrey_camera_driver/src/node.cpp
+++ b/pointgrey_camera_driver/src/node.cpp
@@ -38,7 +38,8 @@ int main(int argc, char **argv)
   nodelet::Loader nodelet;
   nodelet::M_string remap(ros::names::getRemappings());
   nodelet::V_string nargv;
-  nodelet.load("pointgrey_camera_node", "pointgrey_camera_driver/PointGreyCameraNodelet", remap, nargv);
+  std::string nodelet_name = ros::this_node::getName();
+  nodelet.load(nodelet_name, "pointgrey_camera_driver/PointGreyCameraNodelet", remap, nargv);
 
   ros::spin();
 


### PR DESCRIPTION
Always loading nodelets into the same process gets conflicts.  Now each node loads its own copy.
