### PR TITLE
Binning information removed from camera_info published by the nodelet.

### DIFF
--- a/pointgrey_camera_driver/src/nodelet.cpp
+++ b/pointgrey_camera_driver/src/nodelet.cpp
@@ -99,6 +99,9 @@ private:
       wb_red_ = config.white_balance_red;
 
       // Store CameraInfo binning information
+      binning_x_ = 1;
+      binning_y_ = 1;
+      /*     
       if(config.video_mode == "640x480_mono8" || config.video_mode == "format7_mode1")
       {
         binning_x_ = 2;
@@ -114,6 +117,7 @@ private:
         binning_x_ = 0;
         binning_y_ = 0;
       }
+      */
 
       // Store CameraInfo RegionOfInterest information
       if(config.video_mode == "format7_mode0" || config.video_mode == "format7_mode1" || config.video_mode == "format7_mode2")


### PR DESCRIPTION
Removed changes to binning_x and binning_y in camera info messages published by the nodelet (otherwise if an image_proc or stereo_image_proc node is launched, it would perform a further downsampling).
