### PR TITLE
Change approach to downloading flycapture SDK.

### DIFF
--- a/pointgrey_camera_driver/cmake/DownloadFlyCap.cmake
+++ b/pointgrey_camera_driver/cmake/DownloadFlyCap.cmake
@@ -2,41 +2,16 @@ function(download_flycap POINTGREY_LIB_VAR POINTGREY_INCLUDE_DIR_VAR)
   if(NOT UNIX)
     message(FATAL_ERROR "Downloading libflycapture for non-linux systems not supported")
   endif()
+
   include(cmake/TargetArch.cmake)
-  set(POINTGREY_URL_BASE "http://www.ptgrey.com/support/downloads/downloads_admin/Dlds/")
-  set(POINTGREY_ARCHIVE_x86_64 "flycapture2-2.6.3.2-amd64-pkg.tgz")
-  set(POINTGREY_ARCHIVE_i386 "flycapture2-2.6.3.2-i386-pkg.tgz")
-  # set(POINTGREY_ARCHIVE_armv7 "flycapture.2.6.3.2_armhf.tar.gz")
-
-  set(POINTGREY_SO_DEB_x86_64 "flycapture2-2.6.3.2-amd64/libflycapture-2.6.3.2_amd64.deb")
-  set(POINTGREY_HEADER_DEB_x86_64 "flycapture2-2.6.3.2-amd64/libflycapture-2.6.3.2_amd64-dev.deb")
-  set(POINTGREY_SO_DEB_i386 "flycapture2-2.6.3.2-i386/libflycapture-2.6.3.2_i386.deb")
-  set(POINTGREY_HEADER_DEB_i386 "flycapture2-2.6.3.2-i386/libflycapture-2.6.3.2_i386-dev.deb")
-
   target_architecture(POINTGREY_ARCH)
-  if(NOT DEFINED POINTGREY_ARCHIVE_${POINTGREY_ARCH})
-    message(FATAL_ERROR "No support at this time for ${POINTGREY_ARCH} architecture.")
-  endif()
-  set(POINTGREY_ARCHIVE ${POINTGREY_ARCHIVE_${POINTGREY_ARCH}})
-  if(EXISTS "${CMAKE_CURRENT_BINARY_DIR}/${POINTGREY_ARCHIVE}")
-    message(STATUS "Using already-downloaded copy of ${POINTGREY_ARCHIVE}")
-  else()
-    message(STATUS "From ptgrey.com, downloading ${POINTGREY_ARCHIVE} (~9MB)")
-    file(DOWNLOAD "${POINTGREY_URL_BASE}${POINTGREY_ARCHIVE}" 
-                  "${CMAKE_CURRENT_BINARY_DIR}/${POINTGREY_ARCHIVE}")
-  endif()
 
   set(POINTGREY_LIB "${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_LIB_DESTINATION}/libflycapture.so.2")
+  set(DOWNLOAD_SCRIPT "${PROJECT_SOURCE_DIR}/cmake/download_flycap")
   execute_process(
-    COMMAND ${CMAKE_COMMAND} -E tar -zxvf ${POINTGREY_ARCHIVE}
+    COMMAND ${DOWNLOAD_SCRIPT} ${POINTGREY_ARCH} ${POINTGREY_LIB}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-  execute_process(
-    COMMAND dpkg --extract ${POINTGREY_HEADER_DEB_${POINTGREY_ARCH}} ${CMAKE_CURRENT_BINARY_DIR}
-    COMMAND dpkg --extract ${POINTGREY_SO_DEB_${POINTGREY_ARCH}} ${CMAKE_CURRENT_BINARY_DIR}
-    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
-  execute_process(
-    COMMAND ${CMAKE_COMMAND} -E copy "${CMAKE_CURRENT_BINARY_DIR}/usr/lib/libflycapture.so.2.6.3.2"
-                                     "${POINTGREY_LIB}")
+
   set(${POINTGREY_LIB_VAR} ${POINTGREY_LIB} PARENT_SCOPE)
   set(${POINTGREY_INCLUDE_DIR_VAR} "${CMAKE_CURRENT_BINARY_DIR}/usr/include" PARENT_SCOPE)
 endfunction()

--- a/pointgrey_camera_driver/cmake/download_flycap
+++ b/pointgrey_camera_driver/cmake/download_flycap
@@ -1,0 +1,80 @@
+#!/usr/bin/env python
+#
+# Software License Agreement (BSD)
+#
+# @author    Mike Purvis <mpurvis@clearpathrobotics.com>
+# @copyright (c) 2014, Clearpath Robotics, Inc., All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without modification, are permitted provided that
+# the following conditions are met:
+# * Redistributions of source code must retain the above copyright notice, this list of conditions and the
+#   following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice, this list of conditions and the
+#   following disclaimer in the documentation and/or other materials provided with the distribution.
+# * Neither the name of Clearpath Robotics nor the names of its contributors may be used to endorse or
+#   promote products derived from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+# WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+# PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+# ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+# TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+# NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import cookielib
+import cStringIO
+import logging
+import shutil
+import subprocess
+import sys
+import tarfile
+import urllib
+import urllib2
+
+logging.basicConfig(level=logging.INFO)
+
+LOGIN_URL = 'https://www.ptgrey.com/login'
+LOGIN_DATA = {
+    'Email': 'code@clearpathrobotics.com',
+    'Password': 'uNjRxoH6NMsJvi6hyPCH'
+    }
+
+ARCHS = {
+    'x86_64': (
+        'https://www.ptgrey.com/support/downloads/10322', (
+            'flycapture2-2.7.3.13-amd64/libflycapture-2.7.3.13_amd64.deb',
+            'flycapture2-2.7.3.13-amd64/libflycapture-2.7.3.13_amd64-dev.deb'),
+        'usr/lib/libflycapture.so.2.7.3.13'),
+    'i386': (
+        'https://www.ptgrey.com/support/downloads/10323', (
+            'flycapture2-2.7.3.13-i386/libflycapture-2.7.3.13_i386.deb',
+            'flycapture2-2.7.3.13-i386/libflycapture-2.7.3.13_i386-dev.deb'),
+        'usr/lib/libflycapture.so.2.7.3.13')
+    }
+
+archive_url, debs, shared_library = ARCHS[sys.argv[1]]
+library_dest = sys.argv[2]
+
+logging.info("Logging into ptgrey.com.")
+cj = cookielib.CookieJar()
+opener = urllib2.build_opener(urllib2.HTTPCookieProcessor(cj))
+opener.addheaders = [
+    ('User-agent', 'Mozilla/5.0'),
+    ('Referer', 'https://www.ptgrey.com')]
+opener.open(LOGIN_URL, urllib.urlencode(LOGIN_DATA))
+
+logging.info("Downloading SDK archive.")
+resp = opener.open(archive_url)
+
+logging.info("Unpacking tarball.")
+with tarfile.open(mode="r:gz", fileobj=cStringIO.StringIO(resp.read())) as tar:
+    tar.extractall()
+
+for deb in debs:
+    logging.info("Extracting: %s", deb)
+    subprocess.check_call(['dpkg', '--extract', deb, '.'])
+
+logging.info("Copying shared library.")
+shutil.copyfile(shared_library, library_dest)


### PR DESCRIPTION
The logic which fetches and extracts the archive from ptgrey.com
has been moved to a more reasonable and comprehensible python script.
This should better pave the way for better future ARM support in this
driver.

This change also allows us to authenticate the download, resolving #25.
