### PR TITLE
Fix for issue #27

### DIFF
--- a/pointgrey_camera_driver/include/pointgrey_camera_driver/PointGreyCamera.h
+++ b/pointgrey_camera_driver/include/pointgrey_camera_driver/PointGreyCamera.h
@@ -175,6 +175,9 @@ private:
   boost::mutex mutex_; ///< A mutex to make sure that we don't try to grabImages while reconfiguring or vice versa.  Implemented with boost::mutex::scoped_lock.
   volatile bool captureRunning_; ///< A status boolean that checks if the camera has been started and is loading images into its buffer.ù
   
+  /// If true, camera is currently running in color mode, otherwise camera is running in mono mode
+  bool isColor_;
+
   // For GigE cameras:
   /// If true, GigE packet size is automatically determined, otherwise packet_size_ is used:
   bool auto_packet_size_;


### PR DESCRIPTION
Moved the GetCameraInfo calls from grabImage() method. I tested this with PtGrey Flea3 camera. The camera was set to 60fps. The hz of the published image_raw improved from 45hz to 51hz.