### PR TITLE
Add auto white balance and fix not able to write white balance

### DIFF
--- a/pointgrey_camera_driver/cfg/PointGrey.cfg
+++ b/pointgrey_camera_driver/cfg/PointGrey.cfg
@@ -105,6 +105,8 @@ gen.add("brightness",         double_t, SensorLevels.RECONFIGURE_RUNNING,     "B
 
 gen.add("gamma",              double_t, SensorLevels.RECONFIGURE_RUNNING,     "Gamma expansion exponent.",				             		             1.0, 0.5, 4.0)
 
+gen.add("auto_white_balance", bool_t,    SensorLevels.RECONFIGURE_RUNNING,     "Automatically change white balance", True)
+
 gen.add("white_balance_blue", int_t,    SensorLevels.RECONFIGURE_RUNNING,     "White balance blue component.",				             		             800, 0, 1023)
 
 gen.add("white_balance_red",  int_t,    SensorLevels.RECONFIGURE_RUNNING,     "White balance red component.",				             		             550, 0, 1023)

--- a/pointgrey_camera_driver/include/pointgrey_camera_driver/PointGreyCamera.h
+++ b/pointgrey_camera_driver/include/pointgrey_camera_driver/PointGreyCamera.h
@@ -129,7 +129,7 @@ public:
   * \param id serial number for the camera.  Should be something like 10491081.
   */
   void setDesiredCamera(const uint32_t &id);
-  
+
   /*!
   * \brief Set parameters relative to GigE cameras.
   *
@@ -151,7 +151,7 @@ public:
 
   void setGain(double &gain);
 
-  void setBRWhiteBalance(uint16_t &blue, uint16_t &red);
+  void setBRWhiteBalance(bool auto_white_balance, uint16_t &blue, uint16_t &red);
 
   uint getGain();
 
@@ -174,7 +174,7 @@ private:
 
   boost::mutex mutex_; ///< A mutex to make sure that we don't try to grabImages while reconfiguring or vice versa.  Implemented with boost::mutex::scoped_lock.
   volatile bool captureRunning_; ///< A status boolean that checks if the camera has been started and is loading images into its buffer.ù
-  
+
   // For GigE cameras:
   /// If true, GigE packet size is automatically determined, otherwise packet_size_ is used:
   bool auto_packet_size_;
@@ -257,7 +257,7 @@ private:
   *
   * \return Returns true when the configuration could be applied without modification.
   */
-  bool setWhiteBalance(uint16_t &blue, uint16_t &red);
+  bool setWhiteBalance(bool& auto_white_balance, uint16_t &blue, uint16_t &red);
 
   /*!
   * \brief Gets the current frame rate.
@@ -320,7 +320,7 @@ private:
   * \param packet_size The packet size value to use.
   */
   void setupGigEPacketSize(FlyCapture2::PGRGuid & guid, unsigned int packet_size);
-  
+
   /*!
   * \brief Will configure the packet delay of the GigECamera with the given GUID to a given value.
   *

--- a/pointgrey_camera_driver/src/nodelet.cpp
+++ b/pointgrey_camera_driver/src/nodelet.cpp
@@ -396,7 +396,7 @@ private:
       pg_.setGain(gain_);
       wb_blue_ = msg.white_balance_blue;
       wb_red_ = msg.white_balance_red;
-      pg_.setBRWhiteBalance(wb_blue_, wb_red_);
+      pg_.setBRWhiteBalance(false, wb_blue_, wb_red_);
     }
     catch(std::runtime_error& e)
     {

--- a/pointgrey_camera_driver/src/stereo_nodelet.cpp
+++ b/pointgrey_camera_driver/src/stereo_nodelet.cpp
@@ -333,7 +333,7 @@ private:
       pg_.setGain(gain_);
       wb_blue_ = msg.white_balance_blue;
       wb_red_ = msg.white_balance_red;
-      pg_.setBRWhiteBalance(wb_blue_, wb_red_);
+      pg_.setBRWhiteBalance(false, wb_blue_, wb_red_);
     }
     catch(std::runtime_error& e)
     {


### PR DESCRIPTION
Fix the problem of not being able to set white balance using Property.
When trying to set white balance on my FL3-U3-13E4C-C, both this ros
driver and flycap software cannot set the white balance naturally.
After playing around with the flycap software, I found that I have
to set the highest bit of register 80C (which is white balance) to 1
to enable this feature. So I modified the original SetWhiteBalance to
use WriteRegister directly. And add support for auto white balance.

I currently don't have other pointgrey cameras, so I cannot verify
that this will work for sure. Also, when initially launched, since the 
frame rate is low (7.5hz), it will some time for the auto white balance
to converge to the right values. So the entire image would look green
and gradually become normal.