### PR TITLE
Removing check for number of subscribers (in nodelet) to publish raw image

### DIFF
--- a/pointgrey_camera_driver/src/nodelet.cpp
+++ b/pointgrey_camera_driver/src/nodelet.cpp
@@ -350,10 +350,7 @@ private:
         wfov_image->info = *ci_;
 
         // Publish the full message
-        if(pub_->getPublisher().getNumSubscribers() > 0)
-        {
-          pub_->publish(wfov_image);
-        }
+        pub_->publish(wfov_image);
 
         // Publish the message using standard image transport
         if(it_pub_.getNumSubscribers() > 0)


### PR DESCRIPTION
Removing check for number of subscribers to publish raw image - there are checks in place in ROS to serialize messages only if necessary. This check leads to frequency warnings