### PR TITLE
Add Startech vendor ID

### DIFF
--- a/pointgrey_camera_driver/udev/60-pgr.rules
+++ b/pointgrey_camera_driver/udev/60-pgr.rules
@@ -28,4 +28,6 @@ KERNEL=="raw1394", MODE="0666", GROUP="pgrimaging"
 KERNEL=="video1394*", MODE="0666", GROUP="pgrimaging"
 KERNEL=="fw*", SUBSYSTEM=="firewire", ATTR{vendor}=="0x00b09d", MODE="0666", GROUP="pgrimaging"
 KERNEL=="fw*", SUBSYSTEM=="firewire", ATTR{vendor}=="0x00a02d", MODE="0666", GROUP="pgrimaging"
+KERNEL=="fw*", SUBSYSTEM=="firewire", ATTR{vendor}=="0xd00d1e", MODE="0666", GROUP="pgrimaging"
+
 


### PR DESCRIPTION
Adds the vendor ID for Startech-brand Firewire interface cards.  This is necessary for accessing the camera(s) connected through the card.