### PR TITLE
Specify color coding.

### DIFF
--- a/pointgrey_camera_driver/launch/bumblebee.launch
+++ b/pointgrey_camera_driver/launch/bumblebee.launch
@@ -13,6 +13,7 @@
       <param name="frame_rate" value="15" />
       <param name="first_namespace" value="left" />
       <param name="second_namespace" value="right" />
+      <param name="format7_color_coding" value="raw16" />
       <param name="serial" value="$(arg bumblebee_serial)" />
       
       <!-- Use the camera_calibration package to create these files -->


### PR DESCRIPTION
Without the format7 color coding specified, the driver will crash with the following error:

Reconfigure Callback failed with error: PointGreyCamera::setFormat7 Error validating Format 7 settings | FlyCapture2::ErrorType 22Error setting Format 7 information.

Specifying the coding allows the driver to start up properly.