### PR TITLE
update flycap SDK to 2.9.3.13

### DIFF
--- a/pointgrey_camera_driver/cmake/download_flycap
+++ b/pointgrey_camera_driver/cmake/download_flycap
@@ -44,15 +44,15 @@ LOGIN_DATA = {
 
 ARCHS = {
     'x86_64': (
-        'https://www.ptgrey.com/support/downloads/10051', (
-            'flycapture2-2.6.3.4-amd64/libflycapture-2.6.3.4_amd64.deb',
-            'flycapture2-2.6.3.4-amd64/libflycapture-2.6.3.4_amd64-dev.deb'),
-        'usr/lib/libflycapture.so.2.6.3.4'),
+        'https://www.ptgrey.com/support/downloads/10594', (
+            'flycapture2-2.9.3.13-amd64/libflycapture-2.9.3.13_amd64.deb',
+            'flycapture2-2.9.3.13-amd64/libflycapture-2.9.3.13_amd64-dev.deb'),
+        'usr/lib/libflycapture.so.2.9.3.13'),
     'i386': (
-        'https://www.ptgrey.com/support/downloads/10049', (
-            'flycapture2-2.6.3.4-i386/libflycapture-2.6.3.4_i386.deb',
-            'flycapture2-2.6.3.4-i386/libflycapture-2.6.3.4_i386-dev.deb'),
-        'usr/lib/libflycapture.so.2.6.3.4'),
+        'https://www.ptgrey.com/support/downloads/10592', (
+            'flycapture2-2.9.3.13-i386/libflycapture-2.9.3.13_i386.deb',
+            'flycapture2-2.9.3.13-i386/libflycapture-2.9.3.13_i386-dev.deb'),
+        'usr/lib/libflycapture.so.2.9.3.13'),
    'armv7': (
         'http://www.ptgrey.com/support/downloads/10047/', 
             'flycapture.2.6.3.4_armhf',


### PR DESCRIPTION
Lately the PTGray support told me that they fixed the problem with multi-camera setups. I have tested it with two Blackfly cameras and i can confirm that #28 is solved in this version. It looks that we can think about updating the SDK.

In this PR SDK is updated for i386 and amd64. I left armv7 as is because i don't have hardware to test it.