### PR TITLE
Update flycap SDK to 2.10.3.169 needed for Ubuntu 16.04

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,16 @@
+sudo: required
+dist: trusty
 language: cpp
 compiler: gcc
 before_install:
   - sudo pip install rosdep
   - sudo rosdep init && rosdep update 
-  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu precise main" > /etc/apt/sources.list.d/ros-latest.list'
+  - sudo sh -c 'echo "deb http://packages.ros.org/ros/ubuntu trusty main" > /etc/apt/sources.list.d/ros-latest.list'
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update -qq
 install:
-  - rosdep install --from-paths .. --ignore-src --rosdistro hydro
-  - source /opt/ros/hydro/setup.bash
+  - rosdep install --from-paths .. --ignore-src --rosdistro indigo
+  - source /opt/ros/indigo/setup.bash
   - mkdir -p ~/catkin_ws/src && pushd ~/catkin_ws
   - catkin_init_workspace src
   - ln -s `eval echo $(dirs +1)` src/

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install:
   - wget http://packages.ros.org/ros.key -O - | sudo apt-key add -
   - sudo apt-get update -qq
 install:
-  - rosdep install --from-paths .. --ignore-src --rosdistro indigo
+  - rosdep install --from-paths .. --ignore-src --rosdistro indigo --default-yes
   - source /opt/ros/indigo/setup.bash
   - mkdir -p ~/catkin_ws/src && pushd ~/catkin_ws
   - catkin_init_workspace src

--- a/pointgrey_camera_driver/cmake/download_flycap
+++ b/pointgrey_camera_driver/cmake/download_flycap
@@ -44,15 +44,15 @@ LOGIN_DATA = {
 
 ARCHS = {
     'x86_64': (
-        'https://www.ptgrey.com/support/downloads/10617', (
-            'flycapture2-2.9.3.43-amd64/libflycapture-2.9.3.43_amd64.deb',
-            'flycapture2-2.9.3.43-amd64/libflycapture-2.9.3.43_amd64-dev.deb'),
-        'usr/lib/libflycapture.so.2.9.3.43'),
+        'https://www.ptgrey.com/support/downloads/10661', (
+            'flycapture2-2.10.3.169-amd64/libflycapture-2.10.3.169_amd64.deb',
+            'flycapture2-2.10.3.169-amd64/libflycapture-2.10.3.169_amd64-dev.deb'),
+        'usr/lib/libflycapture.so.2.10.3.169'),
     'i386': (
         'https://www.ptgrey.com/support/downloads/10619', (
-            'flycapture2-2.9.3.43-i386/libflycapture-2.9.3.43_i386.deb',
-            'flycapture2-2.9.3.43-i386/libflycapture-2.9.3.43_i386-dev.deb'),
-        'usr/lib/libflycapture.so.2.9.3.43'),
+            'flycapture2-2.9.3.43-i386/libflycapture-2.10.3.169_i386.deb',
+            'flycapture2-2.9.3.43-i386/libflycapture-2.10.3.169_i386-dev.deb'),
+        'usr/lib/libflycapture.so.2.10.3.169'),
     'armv7': (
         'http://www.ptgrey.com/support/downloads/10047/', 
             'flycapture.2.6.3.4_armhf',


### PR DESCRIPTION
Only tested with Ubuntu 16.04 and ROS Kinetic.
