### PR TITLE
Reconnect on error

### DIFF
--- a/pointgrey_camera_driver/src/PointGreyCamera.cpp
+++ b/pointgrey_camera_driver/src/PointGreyCamera.cpp
@@ -1148,6 +1148,6 @@ void PointGreyCamera::handleError(const std::string &prefix, const FlyCapture2::
     std::stringstream out;
     out << error.GetType();
     std::string desc(error.GetDescription());
-    throw std::runtime_error(prefix + start + out.str() + desc);
+    throw std::runtime_error(prefix + start + out.str() + " " + desc);
   }
 }

--- a/pointgrey_camera_driver/src/nodelet.cpp
+++ b/pointgrey_camera_driver/src/nodelet.cpp
@@ -240,7 +240,7 @@ private:
   */
   void onInit()
   {
-	// Get nodeHandles
+    // Get nodeHandles
     ros::NodeHandle &nh = getMTNodeHandle();
     ros::NodeHandle &pnh = getMTPrivateNodeHandle();
 


### PR DESCRIPTION
This implements the recovery strategy that was commented out, when an exception is thrown.

The strategy does: `disconnect` + `connect` + `start`.
From my tests, there's no need to call `stop` before `disconnect`.

If any of the three steps fail, it's tried again after one second.
From my tests, none of them fails.

I need this because after many hours running the camera, if fails to grab images or query the temperature property in the `devicePoll` loop:
https://github.com/ros-drivers/pointgrey_camera_driver/blob/master/pointgrey_camera_driver/src/nodelet.cpp#L315

Since it's very difficult to reproduce, I've forced an error to happen every 10 iterations, when the `TEMPERATURE` property is read, with this code diff:

``` diff
diff --git a/pointgrey_camera_driver/src/PointGreyCamera.cpp b/pointgrey_camera_driver/src/PointGreyCamera.cpp
index a40a415..eea8f3c 100644
--- a/pointgrey_camera_driver/src/PointGreyCamera.cpp
+++ b/pointgrey_camera_driver/src/PointGreyCamera.cpp
@@ -596,8 +596,15 @@ void PointGreyCamera::setTimeout(const double &timeout)

 float PointGreyCamera::getCameraTemperature()
 {
+  static int i = 0;
+  ++i;
   Property tProp;
   tProp.type = TEMPERATURE;
+  if ((i % 10) == 0)
+  {
+    std::cout << "Using bad property on purpose!" << std::endl;
+    tProp.type = static_cast<FlyCapture2::PropertyType>(999999); // @todo force error to check recovery
+  }
   Error error = cam_.GetProperty(&tProp);
   PointGreyCamera::handleError("PointGreyCamera::getCameraTemperature Could not get property.", error);
   return tProp.valueA / 10.0f - 273.15f;  // It returns values of 10 * K
```

After applying that change, we can reproduce/force an error to happen and see that the camera driver recovers gracefully, running this in different terminals:

``` bash
$ roscore

$ rosrun nodelet nodelet manager

$ rosrun nodelet nodelet load pointgrey_camera_driver/PointGreyCameraNodelet manager

$ rosrun image_view image_view image:=/image_raw
```

The output would be like this:

``` bash
Using bad property on purpose!
[ERROR] [1472676083.831936506]: PointGreyCamera::getCameraTemperature Could not get property. | FlyCapture2::ErrorType 1Feature lookup failed.
[INFO] [1472676083.835239900]: Disconnected from camera.
[INFO] [1472676083.852287185]: Connected to camera.
[ INFO] [1472676083.858863462]: Started camera.

```

:exclamation: If we don't handle the errors, as in the original code:
https://github.com/ros-drivers/pointgrey_camera_driver/blob/master/pointgrey_camera_driver/src/nodelet.cpp#L371
the loop iterates very fast spamming the logs, with catastrophic consequences for the system (out of memory issues because of flooding `/rosout` mainly).
It's important to note that the loop doesn't have any blocking functions other than `grabImage`, so when it fails, it returns immediately and we can have up to `1000` log errors per second.

@mikepurvis 