### PR TITLE
Added the option to use the format7_mode4. 

### DIFF
--- a/pointgrey_camera_driver/src/PointGreyCamera.cpp
+++ b/pointgrey_camera_driver/src/PointGreyCamera.cpp
@@ -360,6 +360,11 @@ bool PointGreyCamera::getVideoModeFromString(std::string &vmode, FlyCapture2::Vi
     fmt7Mode = MODE_3;
     vmode_out = VIDEOMODE_FORMAT7;
   }
+  else if(vmode.compare("format7_mode4") == 0)
+  {
+    fmt7Mode = MODE_4;
+    vmode_out = VIDEOMODE_FORMAT7;
+  }
   else    // Something not supported was asked of us, drop down into the most compatible mode
   {
     vmode = "640x480_mono8";


### PR DESCRIPTION
This allows to use the mode4 which corresponds to a 2x2 binning. Example: an image of 1000x800 becomes an image of 500x400. I tested on a flea usb 3.0 camera.