### PR TITLE
Added video_mode Format7_Mode4 option in dynamic reconfigure

### DIFF
--- a/pointgrey_camera_driver/cfg/PointGrey.cfg
+++ b/pointgrey_camera_driver/cfg/PointGrey.cfg
@@ -83,6 +83,7 @@ video_modes = gen.enum([gen.const("Format0_Mode5", str_t, "640x480_mono8", ""),
                   gen.const("Format7_Mode1", str_t, "format7_mode1", ""),
                   gen.const("Format7_Mode2", str_t, "format7_mode2", ""),
 		  gen.const("Format7_Mode3", str_t, "format7_mode3", ""),
+		  gen.const("Format7_Mode4", str_t, "format7_mode4", ""),
                   ],
                  "Video mode for camera.")
 


### PR DESCRIPTION
```Format7_Mode4``` is implemented in pull request #84, but it is not yet added to dynamic reconfigure. This pull request adds ```Format7_Mode4``` to ```video_mode``` in dynamic reconfigure. 

Tested with FL3-U3-32S2C.

Please review and provide feedback.