### PR TITLE
Added a NODELET_INFO to inform the user about the camera_info topic

### DIFF
--- a/pointgrey_camera_driver/src/PointGreyCamera.cpp
+++ b/pointgrey_camera_driver/src/PointGreyCamera.cpp
@@ -360,6 +360,11 @@ bool PointGreyCamera::getVideoModeFromString(std::string &vmode, FlyCapture2::Vi
     fmt7Mode = MODE_3;
     vmode_out = VIDEOMODE_FORMAT7;
   }
+  else if(vmode.compare("format7_mode4") == 0)
+  {
+    fmt7Mode = MODE_4;
+    vmode_out = VIDEOMODE_FORMAT7;
+  }
   else    // Something not supported was asked of us, drop down into the most compatible mode
   {
     vmode = "640x480_mono8";

--- a/pointgrey_camera_driver/src/nodelet.cpp
+++ b/pointgrey_camera_driver/src/nodelet.cpp
@@ -208,8 +208,27 @@ private:
     ros::NodeHandle &pnh = getMTPrivateNodeHandle();
 
     // Get a serial number through ros
-    int serial;
-    pnh.param<int>("serial", serial, 0);
+    int serial = 0;
+
+    XmlRpc::XmlRpcValue serial_xmlrpc;
+    pnh.getParam("serial", serial_xmlrpc);
+    if (serial_xmlrpc.getType() == XmlRpc::XmlRpcValue::TypeInt)
+    {
+      pnh.param<int>("serial", serial, 0);
+    }
+    else if (serial_xmlrpc.getType() == XmlRpc::XmlRpcValue::TypeString)
+    {
+      std::string serial_str;
+      pnh.param<std::string>("serial", serial_str, "0");
+      std::istringstream(serial_str) >> serial;
+    }
+    else
+    {
+      NODELET_DEBUG("Serial XMLRPC type.");
+      serial = 0;
+    }
+    NODELET_INFO("Using camera serial %d", serial);
+
     pg_.setDesiredCamera((uint32_t)serial);
 
     // Get GigE camera parameters:

--- a/pointgrey_camera_driver/src/nodelet.cpp
+++ b/pointgrey_camera_driver/src/nodelet.cpp
@@ -244,7 +244,6 @@ private:
     pnh.param<std::string>("camera_info_url", camera_info_url, "");
     // Get the desired frame_id, set to 'camera' if not found
     pnh.param<std::string>("frame_id", frame_id_, "camera");
-
     // Do not call the connectCb function until after we are done initializing.
     boost::mutex::scoped_lock scopedLock(connect_mutex_);
 
@@ -408,7 +407,7 @@ private:
             NODELET_DEBUG("Starting camera.");
             pg_.start();
             NODELET_INFO("Started camera.");
-
+            NODELET_INFO("Attention: if nothing subscribes to the camera topic, the camera_info is not published on the correspondent topic.");
             state = STARTED;
           }
           catch(std::runtime_error& e)


### PR DESCRIPTION
I don't know if it makes sense or not. But I found myself struggling with the following thing:
"why the camera_info is not being published"

I discovered that if nothing is subscribed to the image published by the camera the camera_info will not be published. Ok, this can make sense but at least I think the user needs an INFO about it. 

what do you think ?