### PR TITLE
Add option to strobe on GPIO2.

### DIFF
--- a/pointgrey_camera_driver/cfg/PointGrey.cfg
+++ b/pointgrey_camera_driver/cfg/PointGrey.cfg
@@ -170,5 +170,14 @@ gen.add("strobe1_polarity", int_t, SensorLevels.RECONFIGURE_RUNNING, "GPIO Strob
 gen.add("strobe1_delay", double_t, SensorLevels.RECONFIGURE_RUNNING, "The delay between capture and strobe out (in milliseconds).", 0.0, 0.0, 1000.0)
 
 gen.add("strobe1_duration", double_t, SensorLevels.RECONFIGURE_RUNNING, "Strobe duration (in milliseconds)", 0.0, 1.0, 1000.0)
+	
+gen.add("enable_strobe2", bool_t, SensorLevels.RECONFIGURE_RUNNING, "Whether strobe is sent.", False)
+
+gen.add("strobe2_polarity", int_t, SensorLevels.RECONFIGURE_RUNNING, "GPIO Strobe Polarity", 0, edit_method = polarities)
+
+gen.add("strobe2_delay", double_t, SensorLevels.RECONFIGURE_RUNNING, "The delay between capture and strobe out (in milliseconds).", 0.0, 0.0, 1000.0)
+
+gen.add("strobe2_duration", double_t, SensorLevels.RECONFIGURE_RUNNING, "Strobe duration (in milliseconds)", 0.0, 1.0, 1000.0)
+
 
 exit(gen.generate(PACKAGE, "pointgrey_camera_driver", "PointGrey"))

--- a/pointgrey_camera_driver/src/PointGreyCamera.cpp
+++ b/pointgrey_camera_driver/src/PointGreyCamera.cpp
@@ -164,6 +164,22 @@ bool PointGreyCamera::setNewConfiguration(pointgrey_camera_driver::PointGreyConf
     default:
       retVal &= false;
   }
+	
+	
+  switch (config.strobe2_polarity)
+  {
+    case pointgrey_camera_driver::PointGrey_Low:
+    case pointgrey_camera_driver::PointGrey_High:
+      {
+      bool temp = config.strobe2_polarity;
+      retVal &= PointGreyCamera::setExternalStrobe(config.enable_strobe2, pointgrey_camera_driver::PointGrey_GPIO2, config.strobe2_duration, config.strobe2_delay, temp);
+      config.strobe2_polarity = temp;
+      }
+      break;
+    default:
+      retVal &= false;
+  }
+
 
   return retVal;
 }


### PR DESCRIPTION
This adds the ability to set a strobe on GPIO2. This is the preferred pin for all none-flea cameras [according to PointGrey ](http://www.ptgrey.com/KB/11052) (where as Flea cameras use the existing hardcoded GPIO1).

Not as elegant as having a [universally settable GPIO pin](https://github.com/ros-drivers/pointgrey_camera_driver/pull/80), but it won't break anyone's code who is depending on that hard coded GPIO1. 