### PR TITLE
Add flycapture2 lib download rule for aarch64(e.g. Jetson TX1)

### DIFF
--- a/pointgrey_camera_driver/cmake/TargetArch.cmake
+++ b/pointgrey_camera_driver/cmake/TargetArch.cmake
@@ -25,7 +25,9 @@
 # "There are many more known variants/revisions that we do not handle/detect."
 
 set(archdetect_c_code "
-#if defined(__arm__) || defined(__TARGET_ARCH_ARM)
+#if defined(__aarch64__)
+        #error cmake_ARCH armv8
+#elif defined(__arm__) || defined(__TARGET_ARCH_ARM)
     #if defined(__ARM_ARCH_7__) \\
         || defined(__ARM_ARCH_7A__) \\
         || defined(__ARM_ARCH_7R__) \\

--- a/pointgrey_camera_driver/cmake/download_flycap
+++ b/pointgrey_camera_driver/cmake/download_flycap
@@ -54,12 +54,17 @@ ARCHS = {
             'flycapture2-2.9.3.43-i386/libflycapture-2.9.3.43_i386-dev.deb'),
         'usr/lib/libflycapture.so.2.9.3.43'),
     'armv7': (
-        'http://www.ptgrey.com/support/downloads/10047/', 
+        'http://www.ptgrey.com/support/downloads/10047/',
             'flycapture.2.6.3.4_armhf',
-            'usr/lib/libflycapture.so.2.6.3.4')
+            'usr/lib/libflycapture.so.2.6.3.4'),
+    'armv8': (
+        'http://www.ptgrey.com/support/downloads/10703/',
+        'flycapture.2.10.3.266_arm64',
+        'usr/lib/libflycapture.so.2.10.3.266')
     }
 
-if (sys.argv[1] == 'armv7'):
+print sys.argv[1]
+if (sys.argv[1] == 'armv7' or sys.argv[1] == 'armv8'):
     archive_url, folder_name, shared_library = ARCHS[sys.argv[1]]
 else:
     archive_url, debs, shared_library = ARCHS[sys.argv[1]]
@@ -81,7 +86,7 @@ logging.info("Unpacking tarball.")
 with tarfile.open(mode="r:gz", fileobj=cStringIO.StringIO(resp.read())) as tar:
     tar.extractall()
 
-if (sys.argv[1] == 'armv7'):
+if (sys.argv[1] == 'armv7' or sys.argv[1] == 'armv8'):
     logging.info("Copying ARM libs from: %s to %s", shared_library, library_dest)
 
     # Creating (current_folder)/usr folder to eliminate need for if branching in 


### PR DESCRIPTION
I have add the new download link for aarch64 processor such as jetson TX1