### PR TITLE
Improve white balance initialisation and logic.

### DIFF
--- a/pointgrey_camera_driver/src/PointGreyCamera.cpp
+++ b/pointgrey_camera_driver/src/PointGreyCamera.cpp
@@ -575,11 +575,14 @@ bool PointGreyCamera::setWhiteBalance(bool &auto_white_balance, uint16_t &blue, 
     // Auto white balance is supported
     error = cam_.WriteRegister(white_balance_addr, enable);
     handleError("PointGreyCamera::setWhiteBalance  Failed to write to register.", error);
+    // Auto mode
     value |= 1 << 24;
   } else {
     // Manual mode
-    value |= blue << 12 | red;
+    value |= 0 << 24;
   }
+  // Blue is bits 8-19 (0 is MSB), red is 20-31.
+  value |= blue << 12 | red;
   error = cam_.WriteRegister(white_balance_addr, value);
   handleError("PointGreyCamera::setWhiteBalance  Failed to write to register.", error);
   return true;


### PR DESCRIPTION
Without this this, we've found that the Chameleon 3 tends to get stuck with a 'green screen' and is not able to adjust the white balance to a reasonable setting.

With this change, auto white balance continues to work using the values in the configuration file as default instead of zeros and auto white balance can be toggled on and off.