### PR TITLE
New rule to download libflycapture depends on the ubuntu releases as well as the arch

### DIFF
--- a/pointgrey_camera_driver/cmake/DownloadFlyCap.cmake
+++ b/pointgrey_camera_driver/cmake/DownloadFlyCap.cmake
@@ -3,13 +3,18 @@ function(download_flycap POINTGREY_LIB_VAR POINTGREY_INCLUDE_DIR_VAR)
     message(FATAL_ERROR "Downloading libflycapture for non-linux systems not supported")
   endif()
 
+  # set architecture
   include(cmake/TargetArch.cmake)
+  # set release
+  execute_process(COMMAND lsb_release -c COMMAND awk "{print $2}" OUTPUT_VARIABLE CODE_NAME)
+  #message(WARNING ${CODE_NAME})
+
   target_architecture(POINTGREY_ARCH)
 
   set(POINTGREY_LIB "${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_LIB_DESTINATION}/libflycapture.so.2")
   set(DOWNLOAD_SCRIPT "${PROJECT_SOURCE_DIR}/cmake/download_flycap")
   execute_process(
-    COMMAND ${DOWNLOAD_SCRIPT} ${POINTGREY_ARCH} ${POINTGREY_LIB}
+    COMMAND ${DOWNLOAD_SCRIPT} ${POINTGREY_ARCH} ${CODE_NAME} ${POINTGREY_LIB}
     WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
 
   set(${POINTGREY_LIB_VAR} ${POINTGREY_LIB} PARENT_SCOPE)

--- a/pointgrey_camera_driver/cmake/DownloadFlyCap.cmake
+++ b/pointgrey_camera_driver/cmake/DownloadFlyCap.cmake
@@ -5,11 +5,10 @@ function(download_flycap POINTGREY_LIB_VAR POINTGREY_INCLUDE_DIR_VAR)
 
   # set architecture
   include(cmake/TargetArch.cmake)
-  # set release
-  execute_process(COMMAND lsb_release -c COMMAND awk "{print $2}" OUTPUT_VARIABLE CODE_NAME)
-  #message(WARNING ${CODE_NAME})
-
   target_architecture(POINTGREY_ARCH)
+  # set release
+  execute_process(COMMAND lsb_release -c COMMAND awk "{print $2}" OUTPUT_VARIABLE RAW_CODE_NAME)
+  string(STRIP ${RAW_CODE_NAME} CODE_NAME)
 
   set(POINTGREY_LIB "${CATKIN_DEVEL_PREFIX}/${CATKIN_PACKAGE_LIB_DESTINATION}/libflycapture.so.2")
   set(DOWNLOAD_SCRIPT "${PROJECT_SOURCE_DIR}/cmake/download_flycap")

--- a/pointgrey_camera_driver/cmake/download_flycap
+++ b/pointgrey_camera_driver/cmake/download_flycap
@@ -48,7 +48,7 @@ VERSION = {
         'https://www.ptgrey.com/support/downloads/10617/', (
             'flycapture2-2.9.3.43-amd64/libflycapture-2.9.3.43_amd64.deb',
             'flycapture2-2.9.3.43-amd64/libflycapture-2.9.3.43_amd64-dev.deb'),
-        'usr/lib/libflycapture.so.2.9.3.43')
+        'usr/lib/libflycapture.so.2.9.3.43'),
       'xenial': (
         'https://www.ptgrey.com/support/downloads/10705', (
             'flycapture2-2.10.3.266-amd64/libflycapture-2.10.3.266_amd64.deb',

--- a/pointgrey_camera_driver/cmake/download_flycap
+++ b/pointgrey_camera_driver/cmake/download_flycap
@@ -42,34 +42,59 @@ LOGIN_DATA = {
     'Password': 'uNjRxoH6NMsJvi6hyPCH'
     }
 
-ARCHS = {
-    'x86_64': (
-        'https://www.ptgrey.com/support/downloads/10617', (
+VERSION = {
+    'x86_64':
+    { 'trusty': (
+        'https://www.ptgrey.com/support/downloads/10617/', (
             'flycapture2-2.9.3.43-amd64/libflycapture-2.9.3.43_amd64.deb',
             'flycapture2-2.9.3.43-amd64/libflycapture-2.9.3.43_amd64-dev.deb'),
-        'usr/lib/libflycapture.so.2.9.3.43'),
-    'i386': (
+        'usr/lib/libflycapture.so.2.9.3.43')
+      'xenial': (
+        'https://www.ptgrey.com/support/downloads/10705', (
+            'flycapture2-2.10.3.266-amd64/libflycapture-2.10.3.266_amd64.deb',
+            'flycapture2-2.10.3.266-amd64/libflycapture-2.10.3.266_amd64-dev.deb'),
+        'usr/lib/libflycapture.so.2.10.3.266')
+    },
+    'i386':
+    { 'trusty': (
         'https://www.ptgrey.com/support/downloads/10619', (
             'flycapture2-2.9.3.43-i386/libflycapture-2.9.3.43_i386.deb',
             'flycapture2-2.9.3.43-i386/libflycapture-2.9.3.43_i386-dev.deb'),
         'usr/lib/libflycapture.so.2.9.3.43'),
-    'armv7': (
-        'http://www.ptgrey.com/support/downloads/10047/',
-            'flycapture.2.6.3.4_armhf',
-            'usr/lib/libflycapture.so.2.6.3.4'),
-    'armv8': (
-        'http://www.ptgrey.com/support/downloads/10703/',
-        'flycapture.2.10.3.266_arm64',
+      'xenial': (
+        'https://www.ptgrey.com/support/downloads/10704/', (
+            'flycapture2-2.10.3.266-i386/libflycapture-2.10.3.266_i386.deb',
+            'flycapture2-2.10.3.266-i386/libflycapture-2.10.3.266_i386-dev.deb'),
         'usr/lib/libflycapture.so.2.10.3.266')
+    },
+    'armv7':
+    { 'trusty':(
+        'http://www.ptgrey.com/support/downloads/10618/',
+            'flycapture.2.9.3.43_armhf',
+            'usr/lib/libflycapture.so.2.9.3.43'),
+      'xenial':(
+        'http://www.ptgrey.com/support/downloads/10702/',
+            'flycapture.2.10.3.266_armhf',
+            'usr/lib/libflycapture.so.2.10.3.266')
+     },
+    'armv8':
+    { 'trusty':(
+        'https://www.ptgrey.com/support/downloads/10616/',
+        'flycapture.2.9.3.43_arm64',
+        'usr/lib/libflycapture.so.2.9.3.43'),
+      'xenial':(
+        'http://www.ptgrey.com/support/downloads/10703/',
+            'flycapture.2.10.3.266_arm64',
+            'usr/lib/libflycapture.so.2.10.3.266')
     }
+}
 
-print sys.argv[1]
 if (sys.argv[1] == 'armv7' or sys.argv[1] == 'armv8'):
-    archive_url, folder_name, shared_library = ARCHS[sys.argv[1]]
+    archive_url, folder_name, shared_library = VERSION[sys.argv[1]][sys.argv[2]]
 else:
-    archive_url, debs, shared_library = ARCHS[sys.argv[1]]
+    archive_url, debs, shared_library = VERSION[sys.argv[1]][sys.argv[2]]
 
-library_dest = sys.argv[2]
+library_dest = sys.argv[3]
 
 logging.info("Logging into ptgrey.com.")
 cj = cookielib.CookieJar()


### PR DESCRIPTION
Since Pointgrey provides  the different libraries according to the ubuntu release versions as well as machine architectures, I add additional code to check the [release](https://github.com/tongtybj/pointgrey_camera_driver/blob/new_version/pointgrey_camera_driver/cmake/DownloadFlyCap.cmake#L10-L11).