### PR TITLE
Download flycapture if header files are missing

### DIFF
--- a/pointgrey_camera_driver/CMakeLists.txt
+++ b/pointgrey_camera_driver/CMakeLists.txt
@@ -20,7 +20,8 @@ catkin_package(
 # contains them. We work around this by downloading the archive directly from
 # their website during this step in the build process.
 find_library(POINTGREY_LIB NAMES libflycapture.so.2 flycapture)
-if(NOT POINTGREY_LIB)
+file(GLOB_RECURSE POINTGREY_HEADER ${POINTGREY_INCLUDE_DIR}*/flycapture/FlyCapture2.h ${CMAKE_CURRENT_BINARY_DIR}/usr/include*/flycapture/FlyCapture2.h)
+if(NOT POINTGREY_LIB OR NOT POINTGREY_HEADER)
   # flycapture not present, must download.
   message(STATUS "libflycapture not found in system library path")
   include(cmake/DownloadFlyCap.cmake)


### PR DESCRIPTION
Build failure when pointgrey_camera_driver is installed in ```/opt/ros``` and built from source in a user's workspace. The workspace source code will find ```libflycapture.so.2``` in ``/opt/ros```, but the header files are missing.

This is solved by requiring the file ```flycapture/FlyCapture2.h``` as well.