### PR TITLE
Added support to RGB8 pixel format and controls for sharpness and saturation

### DIFF
--- a/pointgrey_camera_driver/cfg/PointGrey.cfg
+++ b/pointgrey_camera_driver/cfg/PointGrey.cfg
@@ -94,6 +94,8 @@ gen.add("video_mode", 	      str_t,    SensorLevels.RECONFIGURE_STOP,       "Vid
 gen.add("frame_rate",         double_t, SensorLevels.RECONFIGURE_RUNNING,    "Camera speed (frames per second).",				                             7, 0, 100)
 
 gen.add("auto_exposure",      bool_t,   SensorLevels.RECONFIGURE_RUNNING,    "Allow the camera to automatically change exposure (Combined Gain, Iris & Shutter control).",  True)
+gen.add("auto_sharpness",      bool_t,   SensorLevels.RECONFIGURE_RUNNING,    "Allow the camera to automatically change sharpness.",  True)
+gen.add("auto_saturation",      bool_t,   SensorLevels.RECONFIGURE_RUNNING,    "Allow the camera to automatically change saturation.",  True)
 gen.add("exposure",           double_t, SensorLevels.RECONFIGURE_RUNNING,         "Auto exposure value (like contrast).",				                             1.35, -10.0, 10.0)
 
 gen.add("auto_shutter",       bool_t,   SensorLevels.RECONFIGURE_RUNNING,     "Shutter control state.",				            		                     True)
@@ -109,7 +111,10 @@ gen.add("tilt",               int_t, 	SensorLevels.RECONFIGURE_RUNNING,     "Con
 
 gen.add("brightness",         double_t, SensorLevels.RECONFIGURE_RUNNING,     "Black level offset.",				                                             0.0, 0.0, 10.0)
 
+gen.add("sharpness",         double_t, SensorLevels.RECONFIGURE_RUNNING,     "sharpness.",				                                             1024.0, 0.0, 4095.0)
+gen.add("saturation",         double_t, SensorLevels.RECONFIGURE_RUNNING,     "saturation.",				                                              100.0, 0.0, 100.0)
 gen.add("gamma",              double_t, SensorLevels.RECONFIGURE_RUNNING,     "Gamma expansion exponent.",				             		             1.0, 0.5, 4.0)
+
 
 gen.add("auto_white_balance", bool_t,    SensorLevels.RECONFIGURE_RUNNING,     "Automatically change white balance", True)
 
@@ -129,10 +134,11 @@ gen.add("format7_y_offset", int_t, SensorLevels.RECONFIGURE_STOP,          "Vert
 codings = gen.enum([gen.const("Mono8", str_t, "mono8", ""),
                     gen.const("Mono16", str_t, "mono16", ""),
                     gen.const("Raw8", str_t, "raw8", ""),
-                    gen.const("Raw16", str_t, "raw16", "")],
+                    gen.const("Raw16", str_t, "raw16", ""),
+                    gen.const("RGB8", str_t, "rgb8", "")],
                     "Format7 color coding methods")
 
-gen.add("format7_color_coding", str_t, SensorLevels.RECONFIGURE_STOP,      "Color coding (only for Format7 modes)",                                                       "raw8",      edit_method = codings)
+gen.add("format7_color_coding", str_t, SensorLevels.RECONFIGURE_STOP,      "Color coding (only for Format7 modes)",                                                       "rgb8",      edit_method = codings)
 
 # Trigger parameters
 gen.add("enable_trigger",       bool_t,   SensorLevels.RECONFIGURE_RUNNING,   "Enable the external triggering mode.",                                                        False)
@@ -172,7 +178,7 @@ gen.add("strobe1_polarity", int_t, SensorLevels.RECONFIGURE_RUNNING, "GPIO Strob
 gen.add("strobe1_delay", double_t, SensorLevels.RECONFIGURE_RUNNING, "The delay between capture and strobe out (in milliseconds).", 0.0, 0.0, 1000.0)
 
 gen.add("strobe1_duration", double_t, SensorLevels.RECONFIGURE_RUNNING, "Strobe duration (in milliseconds)", 0.0, 0.0, 1000.0)
-	
+
 gen.add("enable_strobe2", bool_t, SensorLevels.RECONFIGURE_RUNNING, "Whether strobe is sent.", False)
 
 gen.add("strobe2_polarity", int_t, SensorLevels.RECONFIGURE_RUNNING, "GPIO Strobe Polarity", 0, edit_method = polarities)

--- a/pointgrey_camera_driver/cfg/PointGrey.cfg
+++ b/pointgrey_camera_driver/cfg/PointGrey.cfg
@@ -94,8 +94,6 @@ gen.add("video_mode", 	      str_t,    SensorLevels.RECONFIGURE_STOP,       "Vid
 gen.add("frame_rate",         double_t, SensorLevels.RECONFIGURE_RUNNING,    "Camera speed (frames per second).",				                             7, 0, 100)
 
 gen.add("auto_exposure",      bool_t,   SensorLevels.RECONFIGURE_RUNNING,    "Allow the camera to automatically change exposure (Combined Gain, Iris & Shutter control).",  True)
-gen.add("auto_sharpness",      bool_t,   SensorLevels.RECONFIGURE_RUNNING,    "Allow the camera to automatically change sharpness.",  True)
-gen.add("auto_saturation",      bool_t,   SensorLevels.RECONFIGURE_RUNNING,    "Allow the camera to automatically change saturation.",  True)
 gen.add("exposure",           double_t, SensorLevels.RECONFIGURE_RUNNING,         "Auto exposure value (like contrast).",				                             1.35, -10.0, 10.0)
 
 gen.add("auto_shutter",       bool_t,   SensorLevels.RECONFIGURE_RUNNING,     "Shutter control state.",				            		                     True)
@@ -111,10 +109,13 @@ gen.add("tilt",               int_t, 	SensorLevels.RECONFIGURE_RUNNING,     "Con
 
 gen.add("brightness",         double_t, SensorLevels.RECONFIGURE_RUNNING,     "Black level offset.",				                                             0.0, 0.0, 10.0)
 
+gen.add("auto_sharpness",      bool_t,   SensorLevels.RECONFIGURE_RUNNING,    "Allow the camera to automatically change sharpness.",  True)
 gen.add("sharpness",         double_t, SensorLevels.RECONFIGURE_RUNNING,     "sharpness.",				                                             1024.0, 0.0, 4095.0)
-gen.add("saturation",         double_t, SensorLevels.RECONFIGURE_RUNNING,     "saturation.",				                                              100.0, 0.0, 100.0)
-gen.add("gamma",              double_t, SensorLevels.RECONFIGURE_RUNNING,     "Gamma expansion exponent.",				             		             1.0, 0.5, 4.0)
 
+gen.add("auto_saturation",      bool_t,   SensorLevels.RECONFIGURE_RUNNING,    "Allow the camera to automatically change saturation.",  True)
+gen.add("saturation",         double_t, SensorLevels.RECONFIGURE_RUNNING,     "saturation.",				                                              100.0, 0.0, 399.0)
+
+gen.add("gamma",              double_t, SensorLevels.RECONFIGURE_RUNNING,     "Gamma expansion exponent.",				             		             1.0, 0.5, 4.0)
 
 gen.add("auto_white_balance", bool_t,    SensorLevels.RECONFIGURE_RUNNING,     "Automatically change white balance", True)
 
@@ -138,7 +139,7 @@ codings = gen.enum([gen.const("Mono8", str_t, "mono8", ""),
                     gen.const("RGB8", str_t, "rgb8", "")],
                     "Format7 color coding methods")
 
-gen.add("format7_color_coding", str_t, SensorLevels.RECONFIGURE_STOP,      "Color coding (only for Format7 modes)",                                                       "rgb8",      edit_method = codings)
+gen.add("format7_color_coding", str_t, SensorLevels.RECONFIGURE_STOP,      "Color coding (only for Format7 modes)",                                                       "raw8",      edit_method = codings)
 
 # Trigger parameters
 gen.add("enable_trigger",       bool_t,   SensorLevels.RECONFIGURE_RUNNING,   "Enable the external triggering mode.",                                                        False)

--- a/pointgrey_camera_driver/launch/camera.launch
+++ b/pointgrey_camera_driver/launch/camera.launch
@@ -1,4 +1,4 @@
-<launch >
+<launch>
    <!-- Determine this using rosrun pointgrey_camera_driver list_cameras.
        If not specified, defaults to first camera found. -->
   <arg name="camera_name" default="camera" />
@@ -6,23 +6,17 @@
   <arg name="calibrated" default="0" />
 
   <group ns="$(arg camera_name)">
-    <node pkg="nodelet" type="nodelet" name="camera_nodelet_manager" args="manager"/>
+    <node pkg="nodelet" type="nodelet" name="camera_nodelet_manager" args="manager" />
 
     <node pkg="nodelet" type="nodelet" name="camera_nodelet"
           args="load pointgrey_camera_driver/PointGreyCameraNodelet camera_nodelet_manager" >
       <param name="frame_id" value="camera" />
       <param name="serial" value="$(arg camera_serial)" />
-      <param name="format7_color_coding" value="rgb8" />
-      <param name="frame_rate" value="10" />
-     <param name="video_mode" value="format7_mode1" />
-    <!--   <param name="format7_color_coding" value="rgb8" />
-      <param name="frame_rate" value="10" />
-      <param name="mode" value="mode0" />-->
-      <!--format7_mode1-->
+
       <!-- When unspecified, the driver will use the default framerate as given by the
            camera itself. Use this parameter to override that value for cameras capable of
            other framerates. -->
-
+      <!-- <param name="frame_rate" value="15" /> -->
 
       <!-- Use the camera_calibration package to create this file -->
       <param name="camera_info_url" if="$(arg calibrated)"
@@ -32,6 +26,5 @@
     <node pkg="nodelet" type="nodelet" name="image_proc_debayer"
           args="load image_proc/debayer camera_nodelet_manager">
     </node>
-
   </group>
 </launch>

--- a/pointgrey_camera_driver/launch/camera.launch
+++ b/pointgrey_camera_driver/launch/camera.launch
@@ -1,4 +1,4 @@
-<launch>
+<launch >
    <!-- Determine this using rosrun pointgrey_camera_driver list_cameras.
        If not specified, defaults to first camera found. -->
   <arg name="camera_name" default="camera" />
@@ -6,17 +6,23 @@
   <arg name="calibrated" default="0" />
 
   <group ns="$(arg camera_name)">
-    <node pkg="nodelet" type="nodelet" name="camera_nodelet_manager" args="manager" />
+    <node pkg="nodelet" type="nodelet" name="camera_nodelet_manager" args="manager"/>
 
     <node pkg="nodelet" type="nodelet" name="camera_nodelet"
           args="load pointgrey_camera_driver/PointGreyCameraNodelet camera_nodelet_manager" >
       <param name="frame_id" value="camera" />
       <param name="serial" value="$(arg camera_serial)" />
-
+      <param name="format7_color_coding" value="rgb8" />
+      <param name="frame_rate" value="10" />
+     <param name="video_mode" value="format7_mode1" />
+    <!--   <param name="format7_color_coding" value="rgb8" />
+      <param name="frame_rate" value="10" />
+      <param name="mode" value="mode0" />-->
+      <!--format7_mode1-->
       <!-- When unspecified, the driver will use the default framerate as given by the
            camera itself. Use this parameter to override that value for cameras capable of
            other framerates. -->
-      <!-- <param name="frame_rate" value="15" /> -->
+
 
       <!-- Use the camera_calibration package to create this file -->
       <param name="camera_info_url" if="$(arg calibrated)"
@@ -26,5 +32,6 @@
     <node pkg="nodelet" type="nodelet" name="image_proc_debayer"
           args="load image_proc/debayer camera_nodelet_manager">
     </node>
+
   </group>
 </launch>

--- a/pointgrey_camera_driver/src/PointGreyCamera.cpp
+++ b/pointgrey_camera_driver/src/PointGreyCamera.cpp
@@ -65,7 +65,6 @@ bool PointGreyCamera::setNewConfiguration(pointgrey_camera_driver::PointGreyConf
   VideoMode vMode; // video mode desired
   Mode fmt7Mode; // fmt7Mode to set
   retVal &= PointGreyCamera::getVideoModeFromString(config.video_mode, vMode, fmt7Mode);
-
   // Only change video mode if we have to.
   // dynamic_reconfigure will report anything other than LEVEL_RECONFIGURE_RUNNING if we need to change videomode.
   if(level != PointGreyCamera::LEVEL_RECONFIGURE_RUNNING)
@@ -85,6 +84,7 @@ bool PointGreyCamera::setNewConfiguration(pointgrey_camera_driver::PointGreyConf
       config.format7_roi_height = uheight;
       config.format7_x_offset = uoffsetx;
       config.format7_y_offset = uoffsety;
+
     }
     else
     {
@@ -103,6 +103,10 @@ bool PointGreyCamera::setNewConfiguration(pointgrey_camera_driver::PointGreyConf
 
   // Set exposure
   retVal &= PointGreyCamera::setProperty(AUTO_EXPOSURE, config.auto_exposure, config.exposure);
+  // Set sharpness
+  retVal &= PointGreyCamera::setProperty(SHARPNESS, config.auto_sharpness, config.sharpness);
+  // Set saturation
+  retVal &= PointGreyCamera::setProperty(SATURATION, config.auto_saturation, config.saturation);
 
   // Set shutter time
   double shutter = 1000.0 * config.shutter_speed; // Needs to be in milliseconds
@@ -123,11 +127,11 @@ bool PointGreyCamera::setNewConfiguration(pointgrey_camera_driver::PointGreyConf
   retVal &= PointGreyCamera::setProperty(TILT, false, tilt, not_used);
   config.tilt = tilt;
 
-  // Set brightness
-  retVal &= PointGreyCamera::setProperty(BRIGHTNESS, false, config.brightness);
+  // Set BRIGHTNESS
+  retVal &= PointGreyCamera::setProperty(BRIGHTNESS, true, config.brightness);
 
-  // Set gamma
-  retVal &= PointGreyCamera::setProperty(GAMMA, false, config.gamma);
+
+
 
   // Set white balance
   uint16_t blue = config.white_balance_blue;
@@ -165,8 +169,8 @@ bool PointGreyCamera::setNewConfiguration(pointgrey_camera_driver::PointGreyConf
     default:
       retVal &= false;
   }
-	
-	
+
+
   switch (config.strobe2_polarity)
   {
     case pointgrey_camera_driver::PointGrey_Low:
@@ -180,6 +184,9 @@ bool PointGreyCamera::setNewConfiguration(pointgrey_camera_driver::PointGreyConf
     default:
       retVal &= false;
   }
+
+
+
 
 
   return retVal;
@@ -430,6 +437,10 @@ bool PointGreyCamera::getFormat7PixelFormatFromString(std::string &sformat, FlyC
     {
       fmt7PixFmt = PIXEL_FORMAT_MONO16;
     }
+    // if rgb8 is selected
+    else if(sformat.compare("rgb8") == 0){
+      fmt7PixFmt = PIXEL_FORMAT_RGB;
+    }
     else
     {
       sformat = "raw8";
@@ -521,6 +532,8 @@ bool PointGreyCamera::setProperty(const FlyCapture2::PropertyType &type, const b
 
 bool PointGreyCamera::setProperty(const FlyCapture2::PropertyType &type, const bool &autoSet, double &value)
 {
+
+
   // return true if we can set values as desired.
   bool retVal = true;
 
@@ -536,7 +549,6 @@ bool PointGreyCamera::setProperty(const FlyCapture2::PropertyType &type, const b
     prop.autoManualMode = (autoSet && pInfo.autoSupported);
     prop.absControl = pInfo.absValSupported;
     prop.onOff = pInfo.onOffSupported;
-
     if(value < pInfo.absMin)
     {
       value = pInfo.absMin;
@@ -563,6 +575,7 @@ bool PointGreyCamera::setProperty(const FlyCapture2::PropertyType &type, const b
   {
     value = 0.0;
   }
+
   return retVal;
 }
 
@@ -612,6 +625,7 @@ bool PointGreyCamera::setWhiteBalance(bool &auto_white_balance, uint16_t &blue, 
   value |= blue << 12 | red;
   error = cam_.WriteRegister(white_balance_addr, value);
   handleError("PointGreyCamera::setWhiteBalance  Failed to write to register.", error);
+
   return true;
 }
 
@@ -644,7 +658,6 @@ float PointGreyCamera::getCameraFrameRate()
   fProp.type = FRAME_RATE;
   Error error = cam_.GetProperty(&fProp);
   PointGreyCamera::handleError("PointGreyCamera::getCameraFrameRate Could not get property.", error);
-  std::cout << "Frame Rate is: " << fProp.absValue << std::endl;
   return fProp.absValue;
 }
 
@@ -863,6 +876,7 @@ void PointGreyCamera::setupGigEPacketDelay(PGRGuid & guid, unsigned int packet_d
 
 void PointGreyCamera::connect()
 {
+
   if(!cam_.IsConnected())
   {
     Error error;
@@ -884,8 +898,10 @@ void PointGreyCamera::connect()
     FlyCapture2::InterfaceType ifType;
     error = busMgr_.GetInterfaceTypeFromGuid(&guid, &ifType);
     PointGreyCamera::handleError("PointGreyCamera::connect Failed to get interface style of camera", error);
+
     if (ifType == FlyCapture2::INTERFACE_GIGE)
     {
+
 		// Set packet size:
         if (auto_packet_size_)
             setupGigEPacketSize(guid);
@@ -920,13 +936,13 @@ void PointGreyCamera::connect()
     // Enable metadata
     EmbeddedImageInfo info;
     info.timestamp.onOff = true;
-    info.gain.onOff = true;
-    info.shutter.onOff = true;
-    info.brightness.onOff = true;
-    info.exposure.onOff = true;
-    info.whiteBalance.onOff = true;
+    info.gain.onOff = false;
+    info.shutter.onOff = false;
+    info.brightness.onOff = false;
+    info.exposure.onOff = false;
+    info.whiteBalance.onOff = false;
     info.frameCounter.onOff = true;
-    info.ROIPosition.onOff = true;
+    info.ROIPosition.onOff = false;
     error = cam_.SetEmbeddedImageInfo(&info);
     PointGreyCamera::handleError("PointGreyCamera::connect Could not enable metadata", error);
   }
@@ -988,7 +1004,7 @@ void PointGreyCamera::grabImage(sensor_msgs::Image &image, const std::string &fr
     uint8_t bitsPerPixel = rawImage.GetBitsPerPixel();
 
     // Set the image encoding
-    std::string imageEncoding = sensor_msgs::image_encodings::MONO8;
+    std::string imageEncoding = sensor_msgs::image_encodings::RGB8;
     BayerTileFormat bayer_format = rawImage.GetBayerTileFormat();
     if(isColor_ && bayer_format != NONE)
     {
@@ -1035,8 +1051,13 @@ void PointGreyCamera::grabImage(sensor_msgs::Image &image, const std::string &fr
       {
         imageEncoding = sensor_msgs::image_encodings::MONO16;
       }
+      else if(bitsPerPixel==24)
+      {
+        imageEncoding = sensor_msgs::image_encodings::RGB8;
+      }
       else
       {
+
         imageEncoding = sensor_msgs::image_encodings::MONO8;
       }
     }


### PR DESCRIPTION
RGB8 format is not supported in the current driver, which caused dark images when using the camera outdoors. I added RGB8 pixel format to enable the camera to control the saturation and sharpness of the image as well and hence improved the quality of the images.
