### PR TITLE
Debian postinst and postrm scripts to set usbcore values in grub

### DIFF
--- a/pointgrey_camera_driver/debian/postinst
+++ b/pointgrey_camera_driver/debian/postinst
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -e
+
+#DEBHELPER#
+
+# Set the usbfs_memory_mb parameter (lasts until reboot)
+sudo sh -c 'echo 1000 > /sys/module/usbcore/parameters/usbfs_memory_mb'
+
+# Modify grub to set the usbfs_memory_mb parameter at boot time
+file="/etc/default/grub"
+line="GRUB_CMDLINE_LINUX_DEFAULT=\"\$GRUB_CMDLINE_LINUX_DEFAULT usbcore.usbfs_memory_mb=1000\""
+if ! grep -Fxq "$line" $file ; then
+  prev="GRUB_CMDLINE_LINUX_DEFAULT=\"quiet" # Previous line
+  if grep -Fq "$prev" $file ; then
+    sed -i "/$prev/a $line" $file
+  else
+    echo "$line" >> $file
+  fi
+fi
+sudo update-grub
+

--- a/pointgrey_camera_driver/debian/postrm
+++ b/pointgrey_camera_driver/debian/postrm
@@ -1,0 +1,11 @@
+#!/bin/bash
+set -e
+
+#DEBHELPER#
+
+# Remove grub modifications
+file="/etc/default/grub"
+line="GRUB_CMDLINE_LINUX_DEFAULT=\"\$GRUB_CMDLINE_LINUX_DEFAULT usbcore.usbfs_memory_mb=1000\""
+sudo sed -i -e "/$line/d" $file
+sudo update-grub
+


### PR DESCRIPTION
Added postinst and postrm scripts that modify grub to set usbcore.usbfs_memory_mb=1000 at boot. This is recommended in the troubleshooting section of the [wiki](http://wiki.ros.org/pointgrey_camera_driver#Troubleshooting).