### PR TITLE
Use find_path to look for system headers.

### DIFF
--- a/pointgrey_camera_driver/CMakeLists.txt
+++ b/pointgrey_camera_driver/CMakeLists.txt
@@ -21,7 +21,9 @@ catkin_package(CATKIN_DEPENDS
 # contains them. We work around this by downloading the archive directly from
 # their website during this step in the build process.
 find_library(POINTGREY_LIB NAMES libflycapture.so.2 flycapture)
+find_path(POINTGREY_INCLUDE_DIR NAMES flycapture/FlyCapture2.h)
 file(GLOB_RECURSE POINTGREY_HEADER ${POINTGREY_INCLUDE_DIR}*/flycapture/FlyCapture2.h ${CMAKE_CURRENT_BINARY_DIR}/usr/include*/flycapture/FlyCapture2.h)
+
 if(NOT POINTGREY_LIB OR NOT POINTGREY_HEADER)
   # flycapture not present, must download.
   message(STATUS "libflycapture not found in system library path")


### PR DESCRIPTION
This fixes an issue with not finding the library/headers at build time when already installed on the system.

FYI @v-mehta