### PR TITLE
Not closing connection when consistency exception happens.

### DIFF
--- a/pointgrey_camera_driver/include/pointgrey_camera_driver/camera_exceptions.h
+++ b/pointgrey_camera_driver/include/pointgrey_camera_driver/camera_exceptions.h
@@ -55,4 +55,11 @@ public:
   CameraImageNotReadyException(std::string msg): runtime_error(msg.c_str()) {}
 };
 
+class CameraImageConsistencyError: public std::runtime_error
+{
+public:
+  CameraImageConsistencyError(): runtime_error("Image consistency issue.") {}
+  CameraImageConsistencyError(std::string msg): runtime_error(msg.c_str()) {}
+};
+
 #endif

--- a/pointgrey_camera_driver/src/PointGreyCamera.cpp
+++ b/pointgrey_camera_driver/src/PointGreyCamera.cpp
@@ -1216,6 +1216,10 @@ void PointGreyCamera::handleError(const std::string &prefix, const FlyCapture2::
   {
     throw CameraTimeoutException("PointGreyCamera: Failed to retrieve buffer within timeout.");
   }
+  else if(error == PGRERROR_IMAGE_CONSISTENCY_ERROR)
+  {
+    throw CameraImageConsistencyError("PointGreyCamera: Image consistency error.");
+  }
   else if(error != PGRERROR_OK)     // If there is actually an error (PGRERROR_OK means the function worked as intended...)
   {
     std::string start(" | FlyCapture2::ErrorType ");

--- a/pointgrey_camera_driver/src/nodelet.cpp
+++ b/pointgrey_camera_driver/src/nodelet.cpp
@@ -523,6 +523,10 @@ private:
           {
             NODELET_WARN("%s", e.what());
           }
+          catch(CameraImageConsistencyError& e)
+          {
+            NODELET_WARN("%s", e.what());
+          }
           catch(std::runtime_error& e)
           {
             NODELET_ERROR("%s", e.what());


### PR DESCRIPTION
Hi!

I added an exception for error 41, consistency exception. These errors happen once in a while using GigE cameras. 

I see no reason why it would have to re-connect to camera when we get this error from flycapture. Correct?