### PR TITLE
Add messages as build dependencies for driver executables

### DIFF
--- a/pointgrey_camera_driver/CMakeLists.txt
+++ b/pointgrey_camera_driver/CMakeLists.txt
@@ -55,28 +55,33 @@ include_directories(include ${POINTGREY_INCLUDE_DIR} ${catkin_INCLUDE_DIRS})
 
 add_library(PointGreyCamera src/PointGreyCamera.cpp)
 target_link_libraries(PointGreyCamera ${POINTGREY_LIB} ${catkin_LIBRARIES})
-add_dependencies(PointGreyCamera ${PROJECT_NAME}_gencfg)
+add_dependencies(PointGreyCamera ${PROJECT_NAME}_gencfg ${catkin_EXPORTED_TARGETS})
 
 add_library(PointGreyCameraNodelet src/nodelet.cpp)
 target_link_libraries(PointGreyCameraNodelet PointGreyCamera ${catkin_LIBRARIES})
+add_dependencies(PointGreyCameraNodelet ${catkin_EXPORTED_TARGETS})
 
 add_library(PointGreyStereoCameraNodelet src/stereo_nodelet.cpp)
 target_link_libraries(PointGreyStereoCameraNodelet PointGreyCamera ${catkin_LIBRARIES})
+add_dependencies(PointGreyStereoCameraNodelet ${catkin_EXPORTED_TARGETS})
 
 add_executable(pointgrey_camera_node src/node.cpp)
 target_link_libraries(pointgrey_camera_node PointGreyCamera ${catkin_LIBRARIES})
 set_target_properties(pointgrey_camera_node
                       PROPERTIES OUTPUT_NAME camera_node PREFIX "")
+add_dependencies(pointgrey_camera_node ${catkin_EXPORTED_TARGETS})
 
 add_executable(pointgrey_stereo_node src/stereo_node.cpp)
 target_link_libraries(pointgrey_stereo_node PointGreyCamera ${catkin_LIBRARIES})
 set_target_properties(pointgrey_stereo_node
                       PROPERTIES OUTPUT_NAME stereo_node PREFIX "")
+add_dependencies(pointgrey_stereo_node ${catkin_EXPORTED_TARGETS})
 
 add_executable(pointgrey_list_cameras src/list_cameras.cpp)
 target_link_libraries(pointgrey_list_cameras PointGreyCamera ${catkin_LIBRARIES})
 set_target_properties(pointgrey_list_cameras
                       PROPERTIES OUTPUT_NAME list_cameras PREFIX "")
+add_dependencies(pointgrey_list_cameras ${catkin_EXPORTED_TARGETS})
 
 install(TARGETS
   PointGreyCamera


### PR DESCRIPTION
On my project's Jenkins CI, sometimes our [builds were failing[(https://ci.mil.ufl.edu/jenkins/blue/organizations/jenkins/uf-mil%2Fmil_common/detail/PR-92/1/pipeline) on the pointgrey driver because the messages were not yet built. 


http://wiki.ros.org/catkin/CMakeLists.txt#Important_Prerequisites.2BAC8-Constraints