### PR TITLE
Add option to turn off packet resend

### DIFF
--- a/pointgrey_camera_driver/include/pointgrey_camera_driver/PointGreyCamera.h
+++ b/pointgrey_camera_driver/include/pointgrey_camera_driver/PointGreyCamera.h
@@ -144,7 +144,7 @@ public:
   * \param auto_packet_size Flag stating if packet size should be automatically determined or not.
   * \param packet_size The packet size value to use if auto_packet_size is false.
   */
-  void setGigEParameters(bool auto_packet_size, unsigned int packet_size, unsigned int packet_delay);
+  void setGigEParameters(bool auto_packet_size, unsigned int packet_size, unsigned int packet_delay, bool packet_resend);
 
   std::vector<uint32_t> getAttachedCameras();
 
@@ -193,6 +193,9 @@ private:
   unsigned int packet_size_;
   /// GigE packet delay:
   unsigned int packet_delay_;
+  /// If true, GigE packet resend is enabled:
+  unsigned int packet_resend_;
+
 
   /*!
   * \brief Changes the video mode of the connected camera.
@@ -342,6 +345,17 @@ private:
   * \param packet_delay The packet delay value to use.
   */
   void setupGigEPacketDelay(FlyCapture2::PGRGuid & guid, unsigned int packet_delay);
+
+  /*!
+  * \brief Will configure the packet resend option of the GigECamera with the given GUID to the given value.
+  *
+  * Note that this is expected only to work for GigE cameras, and only if the camera
+  * is not connected.
+  *
+  * \param guid the camera to autoconfigure
+  * \param packet_resend Use packet resend option.
+  */
+  void setupGigEPacketResend(FlyCapture2::PGRGuid & guid, bool packet_resend);
 
 public:
   /*!

--- a/pointgrey_camera_driver/include/pointgrey_camera_driver/PointGreyCamera.h
+++ b/pointgrey_camera_driver/include/pointgrey_camera_driver/PointGreyCamera.h
@@ -194,7 +194,7 @@ private:
   /// GigE packet delay:
   unsigned int packet_delay_;
   /// If true, GigE packet resend is enabled:
-  unsigned int packet_resend_;
+  bool packet_resend_;
 
 
   /*!

--- a/pointgrey_camera_driver/launch/camera.launch
+++ b/pointgrey_camera_driver/launch/camera.launch
@@ -4,6 +4,7 @@
   <arg name="camera_name" default="camera" />
   <arg name="camera_serial" default="0" />
   <arg name="calibrated" default="0" />
+  <arg name="packet_resend" default="true" />
 
   <group ns="$(arg camera_name)">
     <node pkg="nodelet" type="nodelet" name="camera_nodelet_manager" args="manager" />
@@ -12,6 +13,7 @@
           args="load pointgrey_camera_driver/PointGreyCameraNodelet camera_nodelet_manager" >
       <param name="frame_id" value="camera" />
       <param name="serial" value="$(arg camera_serial)" />
+      <param name="packet_resend" value="$(arg packet_resend)" />
 
       <!-- When unspecified, the driver will use the default framerate as given by the
            camera itself. Use this parameter to override that value for cameras capable of

--- a/pointgrey_camera_driver/src/nodelet.cpp
+++ b/pointgrey_camera_driver/src/nodelet.cpp
@@ -259,9 +259,10 @@ private:
     pnh.param<int>("packet_size", packet_size_, 1400);
     pnh.param<bool>("auto_packet_size", auto_packet_size_, true);
     pnh.param<int>("packet_delay", packet_delay_, 4000);
+    pnh.param<bool>("packet_resend", packet_resend_, true);
 
     // Set GigE parameters:
-    pg_.setGigEParameters(auto_packet_size_, packet_size_, packet_delay_);
+    pg_.setGigEParameters(auto_packet_size_, packet_size_, packet_delay_, packet_resend_);
 
     // Get the location of our camera config yaml
     std::string camera_info_url;
@@ -600,6 +601,9 @@ private:
   int packet_size_;
   /// GigE packet delay:
   int packet_delay_;
+  /// If true, GigE packet resend is enabled:
+  bool packet_resend_;
+
 
   /// Configuration:
   pointgrey_camera_driver::PointGreyConfig config_;


### PR DESCRIPTION
My camera (Flea3 GigE Camera FL3-GE-14S3C-C) does not work properly with the current git/master. It is not able to turn on the packet_resend option as set by #97 (hardwired) ( Issue #158 ). This PR adds the option to turn off packet resend before runtime.

**ex1**
```bash
cd ~/devel/lib/pointgrey_camera_driver
./camera_node _packet_resend:=false
```
**ex2**
```bash
roslaunch pointgrey_camera_driver camera.launch packet_resend:=false
```

_true_ is still the default value.


