### PR TITLE
raw8 and raw16 are valid for mono cameras

### DIFF
--- a/pointgrey_camera_driver/src/PointGreyCamera.cpp
+++ b/pointgrey_camera_driver/src/PointGreyCamera.cpp
@@ -456,6 +456,14 @@ bool PointGreyCamera::getFormat7PixelFormatFromString(std::string &sformat, FlyC
     {
       fmt7PixFmt = PIXEL_FORMAT_MONO16;
     }
+    else if(sformat.compare("raw8") == 0)
+    {
+      fmt7PixFmt = PIXEL_FORMAT_RAW8;
+    }
+    else if(sformat.compare("raw16") == 0)
+    {
+      fmt7PixFmt = PIXEL_FORMAT_RAW16;
+    }
     else
     {
       sformat = "mono8";


### PR DESCRIPTION
For Grashopper 3 cameras (GS3-U3-41C6M-C), setting 'raw8' mode is the only way
to get 80FPS capture.