### PR TITLE
Add support for software trigger

### DIFF
--- a/pointgrey_camera_driver/cfg/PointGrey.cfg
+++ b/pointgrey_camera_driver/cfg/PointGrey.cfg
@@ -147,7 +147,8 @@ gen.add("enable_trigger",       bool_t,   SensorLevels.RECONFIGURE_RUNNING,   "E
 trigger_modes = gen.enum([gen.const("Mode0", str_t, "mode0", ""),
                     gen.const("Mode1_bulb_trigger", str_t, "mode1", ""),
                     gen.const("Mode3", str_t, "mode3", ""),
-                    gen.const("Mode14", str_t, "mode14", "")],
+                    gen.const("Mode14", str_t, "mode14", ""),
+                    gen.const("Mode15", str_t, "mode15", "")],
                     "IIDC v1.31 Trigger Modes")
 
 gen.add("trigger_mode", str_t, SensorLevels.RECONFIGURE_RUNNING,              "IIDC v1.31 Trigger Modes",                                                                    "mode0",     edit_method = trigger_modes)
@@ -155,7 +156,8 @@ gen.add("trigger_mode", str_t, SensorLevels.RECONFIGURE_RUNNING,              "I
 gpio_pins = gen.enum([gen.const("GPIO0", str_t, "gpio0", ""),
                     gen.const("GPIO1", str_t, "gpio1", ""),
                     gen.const("GPIO2", str_t, "gpio2", ""),
-                    gen.const("GPIO3", str_t, "gpio3", "")],
+                    gen.const("GPIO3", str_t, "gpio3", ""),
+                    gen.const("SOFTWARE", str_t, "software", "")],
                     "GPIO Trigger Sources")
 
 gen.add("trigger_source", str_t, SensorLevels.RECONFIGURE_RUNNING, "GPIO Trigger Sources",                                                                                   "gpio0",     edit_method = gpio_pins)

--- a/pointgrey_camera_driver/include/pointgrey_camera_driver/PointGreyCamera.h
+++ b/pointgrey_camera_driver/include/pointgrey_camera_driver/PointGreyCamera.h
@@ -173,6 +173,8 @@ public:
 
   uint getROIPosition();
 
+  bool fireSoftwareTrigger();
+
 private:
 
   uint32_t serial_; ///< A variable to hold the serial number of the desired camera.

--- a/pointgrey_camera_driver/src/PointGreyCamera.cpp
+++ b/pointgrey_camera_driver/src/PointGreyCamera.cpp
@@ -675,6 +675,10 @@ static int sourceNumberFromGpioName(const std::string s)
   {
     return 3;
   }
+  else if(s.compare("software") == 0)
+  {
+    return 7;
+  }
   else
   {
     // Unrecognized pin
@@ -765,6 +769,10 @@ bool PointGreyCamera::setExternalTrigger(bool &enable, std::string &mode, std::s
   {
     triggerMode.mode = 14;
   }
+  else if(tmode.compare("mode15") == 0)
+  {
+    triggerMode.mode = 15;
+  }
   else
   {
     // Unrecognized mode
@@ -774,6 +782,7 @@ bool PointGreyCamera::setExternalTrigger(bool &enable, std::string &mode, std::s
   }
 
   // Parameter is used for mode3 (return one out of every N frames).  So if N is two, it returns every other frame.
+  // It is also used for mode15 (camera will acquire N images and stop)
   triggerMode.parameter = parameter;
 
   // Set trigger source
@@ -817,6 +826,21 @@ bool PointGreyCamera::setExternalTrigger(bool &enable, std::string &mode, std::s
   delay = triggerDelay.absValue;
 
   return retVal;
+}
+
+bool PointGreyCamera::fireSoftwareTrigger() {
+  const unsigned int k_softwareTrigger = 0x62C;
+  const unsigned int k_fireVal = 0x80000000;
+  Error error;
+
+  error = cam_.WriteRegister(k_softwareTrigger, k_fireVal);
+  if (error != PGRERROR_OK)
+  {
+    PointGreyCamera::handleError("PointGreyCamera::fireSoftwareTrigger Could not fire software trigger.", error);
+    return false;
+  }
+
+  return true;
 }
 
 void PointGreyCamera::setGigEParameters(bool auto_packet_size, unsigned int packet_size, unsigned int packet_delay)


### PR DESCRIPTION
Issue #128 - add support for software trigger for cameras that support it.
You can use it as follows:
```
    <node pkg="nodelet" type="nodelet" name="camera_nodelet"
          args="load pointgrey_camera_driver/PointGreyCameraNodelet camera_nodelet_manager" output="screen">
...
      <param name="frame_rate" value="15" />
      <param name="enable_trigger" value="true" />
      <param name="trigger_mode" value="mode15" />
      <param name="trigger_source" value="software" />
      <param name="trigger_parameter" value="5" />
      <param name="timeout" value="-1" />
...
    </node>
```
then you can publish a `std_msgs/Empty` message on the `trigger` topic (note: that topic only exists if there is at least one consumer connected to the image topics).